### PR TITLE
Made RegEx match better in Firefox.

### DIFF
--- a/src/.firefox/content/loader.js
+++ b/src/.firefox/content/loader.js
@@ -57,6 +57,7 @@ var AutoReviewComments = {
     ];
 
     targetSites.forEach( function( site ) {
+      site = site.replace( "http*", "(http|https)" );
       site = site.replace( "*", ".*?" );
       var siteRegexp = new RegExp( site );
       if( siteRegexp.test( href ) ) {


### PR DESCRIPTION
Modified the per-site RegEx to be slightly more restrictive.  I don't know why, but Firefox wasn't matching on any of the *.stackexchange variations that I tried.  Given that the wild-card appeared to be targeting http and https, this variation seem to match it a little more precisely.

Given the point of modification, this shouldn't affect the other build targets.  However, since the chrome-signing binaries are incompatible with OSX, I don't have the ability to test them.
